### PR TITLE
Pin blockly to version 8.0.0

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,6 +90,6 @@
         </div>
     </body>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+    <script src="https://unpkg.com/blockly@8.0.0/blockly.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
 </html>


### PR DESCRIPTION
I think something changed about the internals of blockly, and I was getting errors about `selectedOption_` not existing from the line `let type = block.inputList[0]?.fieldRow?.[3]?.selectedOption_[0];`.

I went back to a version about the time this repo was last updated.